### PR TITLE
Update Windows CI workflow to use MSYS2 with CLANG64

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: windows
+name: msys2
 
 on:
   workflow_dispatch:
@@ -6,25 +6,36 @@ on:
     paths:
       - '**'
       - '!.github/**'
-      - '.github/workflows/windows.yml'
-      - '!**.md'
+      - '.github/workflows/msys2.yml'
   pull_request:
     paths:
       - '**'
       - '!.github/**'
-      - '.github/workflows/windows.yml'
-      - '!**.md'
+      - '.github/workflows/msys2.yml'
 
 jobs:
-  windows:
-    runs-on: windows-latest
+  msys2:
+    runs-on: ${{matrix.arch.runs-on}}
 
     strategy:
       fail-fast: false
       matrix:
         options: ['', '-DASSISTANTLIB_WITH_OPENSSL=OFF']
+        arch:
+          - msystem: clang64
+            runs-on: windows-latest
 
     steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{matrix.arch.msystem}}
+        update: true
+        pacboy: >-
+          cmake:p
+          make:p
+          clang:p
+          clang-tools-extra:p
+          openssl:p
 
     - name: Checkout assistant
       uses: actions/checkout@v6
@@ -38,7 +49,7 @@ jobs:
       run: |
         mkdir build-release
         cd build-release
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON ${{ matrix.options }}
+        cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON ${{ matrix.options }}
         cmake --build . --config Release --parallel $(nproc)
 
     - name: Run Tests


### PR DESCRIPTION
Renamed the workflow from "windows" to "msys2" to better reflect the build environment being used. Updated the job configuration to use MSYS2 setup action instead of relying on the native Windows environment.

The workflow now explicitly configures the CLANG64 MSYS2 environment and installs required build dependencies (CMake, Make, Clang, Clang-tools-extra, and OpenSSL) through the MSYS2 package manager. Updated the CMake invocation to use the MinGW Makefiles generator, which is compatible with the MSYS2 toolchain.

Removed the markdown file exclusion pattern from the trigger paths since it was overly broad and the workflow-specific path filter is now more precise.

* GitHub Actions workflow configuration
* Build system configuration (CMake generator)
* CI/CD environment setup

**Generated by CodeLite**